### PR TITLE
Run at every `:45` instead of `:00`

### DIFF
--- a/.github/workflows/update-lists.yml
+++ b/.github/workflows/update-lists.yml
@@ -2,7 +2,7 @@ name: Update lists
 
 on:
   schedule:
-  - cron: '0 * * * *' # Run every hour at 0 minutes past the hour
+  - cron: '45 * * * *' # Run every hour at 45 minutes past the hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`brave-core-crx-packager` runs at `:55`, so this will give us lower latency of list publishing.