### PR TITLE
Only consolidate duplicate newlines at the end of the file

### DIFF
--- a/update-lists.py
+++ b/update-lists.py
@@ -64,7 +64,7 @@ def validate_checksum(filename):
 
     # Normalize data
     data = re.sub(r"\r", "", data)
-    data = re.sub(r"\n+", "\n", data)
+    data = re.sub(r"\n+\Z", "\n", data)
 
     # Calculate new checksum
     checksum_expected = hashlib.md5(data.encode("utf-8")).digest()


### PR DESCRIPTION
https://github.com/easylist/EasyListHebrew/commit/287f0e795093157907fed3e8ac8a8f5f88cc0c39 introduced an empty line in EasyList Hebrew, but their checksum calculation and validation code does _not_ consolidate newlines anywhere in the file.

On the other hand,
https://github.com/RealEnder/adblockbg/blob/master/adblockbg.txt has had duplicate newlines at the end of the file for a long time. Their checksum calculation and validation code doesn't appear to be available online anywhere, but this is the only list in our catalog at the moment that has any issues when duplicate newline consolidation is removed.

This change resolves the incompatibility for now, but we probably need to coordinate with the respective maintainers and agree on an actual spec here at some point.